### PR TITLE
Read “mate” path from TextMate's preferences

### DIFF
--- a/Support/bin/edit
+++ b/Support/bin/edit
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-PATH="${PATH}:/usr/local/bin/:${HOME}/bin"
+mate=$(defaults read ~/Library/Preferences/com.macromates.textmate.plist mateInstallPath 2>&1)
 
-if which -s mate; then
-	if [[ "$(mate --version)" = mate\ 2.* ]]
-	then mate --wait --line "${MM_LINE_NUMBER}" --name "${MM_TITLE:-(no subject)}" "${MM_EDIT_FILEPATH}"
-	else mate --wait --line "${MM_LINE_NUMBER}" "${MM_EDIT_FILEPATH}"
-	fi
-else
-	osascript -e 'tell app "MailMate" to display dialog "Make sure you have the “mate” command installed. See the “Terminal” preferences pane within TextMate." buttons "OK" default button 1 with title "Unable to locate TextMate"' >/dev/null 2>&1 &
+if [[ $? != 0 ]]
+then
+    osascript -e 'tell app "MailMate" to display dialog "Make sure you have the “mate” command installed. See the “Terminal” preferences pane within TextMate." buttons "OK" default button 1 with title "Unable to locate TextMate"' >/dev/null 2>&1 &
+    exit 0
 fi
+
+"${mate}" --wait --line "${MM_LINE_NUMBER}" --name "${MM_TITLE:-(no subject)}" "${MM_EDIT_FILEPATH}"


### PR DESCRIPTION
I have `mate` installed in `~/usr/bin`, which this bundle wasn't searching. I think a better solution is to directly read the `mate` path from TextMate's preferences.

I don't think TextMate 1.x is supported on recent macOS releases so I removed the version check.